### PR TITLE
Add subdomain summit.dao.brussels and update Google Doc id

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -79,6 +79,17 @@ module.exports = {
         permanent: false,
         destination: "https://t.me/joinchat/5NbP0-Vl5Vg3MTgx",
       },
+      {
+        source: "/(.*)",
+        has: [
+          {
+            type: "host",
+            value: "summit.dao.brussels",
+          },
+        ],
+        permanent: false,
+        destination: "https://www.getrevue.co/profile/daosummit",
+      },
     ];
   },
 };

--- a/sitemap.json
+++ b/sitemap.json
@@ -13,7 +13,7 @@
   },
   "daosummit": {
     "title": "DAO Summit - a week to discover working for communities - DAO Brussels",
-    "googleDocId": "1WfX59hHSMalOe2_jO5_w_PkpsoRcQef3NDSSiBGj03k",
+    "googleDocId": "1sCGfp9z7V48P3xbf0Ewp0o9Bs8it3fJW1V86_RnUVlQ",
     "description": "Discover the new DAO economy where you can make a living working for communities."
   },
   "faq": {


### PR DESCRIPTION
Hi @xdamman

I added a (temporary) subdomain so we can start collecting leads via a mailing list: https://summit.dao.brussels

I also noticed that the google doc at https://dao.brussels/daosummit was not pointing to the one in the "website" folder of the google drive, so I fixed it.

Can you publish this please?